### PR TITLE
Remove string value support from IN() 

### DIFF
--- a/src/Trilogy/Driver/Sql/SqlAbstract.php
+++ b/src/Trilogy/Driver/Sql/SqlAbstract.php
@@ -588,9 +588,7 @@ abstract class SqlAbstract implements SqlInterface
         } elseif (($op === 'NOT IN' || $op === 'IN') && $value === '?') {
             $whereValue = $where->getValue();
 
-            if (is_string($whereValue)) {
-                $value = $whereValue;
-            } elseif (is_array($whereValue)) {
+            if (is_array($whereValue)) {
                 $where->setValue((array) $where->getValue());
                 $value = $whereValue;
                 $value = str_repeat('?', count($value));

--- a/tests/Test/All/Pgsql.php
+++ b/tests/Test/All/Pgsql.php
@@ -53,18 +53,6 @@ class Pgsql extends UnitAbstract
         $this->assert($values[0] === 'FALSE', 'The boolean true should have been filtered to a string ('. var_export($values[0], true) .')');
     }
 
-    public function subSelect()
-    {
-        $find1 = $this->db->find->in('test')->where('id *', "SELECT id from test WHERE subId > 10");
-        $find2 = $this->db->find->in('test')->where('id !*', "SELECT id from test WHERE subId > 10");
-
-        $comp1 = 'SELECT * FROM "test" WHERE "id" IN (SELECT id from test WHERE subId > 10)';
-        $comp2 = 'SELECT * FROM "test" WHERE "id" NOT IN (SELECT id from test WHERE subId > 10)';
-
-        $this->assert($find1->compile() == $comp1);
-        $this->assert($find2->compile() == $comp2);
-    }
-
     public function subSelectStatement()
     {
         $find1 = $this->db->find->in('test')->where('subId >', 10);


### PR DESCRIPTION
Remove string value support from IN() since params do not get compiled correctly.